### PR TITLE
Update REST Builder modules dependencies using the release.{product}.api dependency

### DIFF
--- a/gradle6-rest-builder/modules/guestbook/build.gradle
+++ b/gradle6-rest-builder/modules/guestbook/build.gradle
@@ -1,5 +1,0 @@
-subprojects {
-	configurations.all {
-		resolutionStrategy.force 'com.liferay:com.liferay.portal.vulcan.api:7.7.1'
-	}
-}

--- a/gradle6-rest-builder/modules/guestbook/guestbook-api/build.gradle
+++ b/gradle6-rest-builder/modules/guestbook/guestbook-api/build.gradle
@@ -1,12 +1,3 @@
 dependencies {
-	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.10.3"
-	compileOnly group: "com.liferay", name: "com.liferay.petra.function"
-	compileOnly group: "com.liferay", name: "com.liferay.petra.string"
-	compileOnly group: "com.liferay", name: "com.liferay.portal.vulcan.api", version: "7.7.1"
-	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel"
-	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
-	compileOnly group: "javax.servlet", name: "javax.servlet-api"
-	compileOnly group: "javax.validation", name: "validation-api", version: "2.0.1.Final"
-	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api"
-	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
+	compileOnly group: "com.liferay.portal", name: "release.dxp.api", version:"7.3.10-ga1"
 }

--- a/gradle6-rest-builder/modules/guestbook/guestbook-impl/build.gradle
+++ b/gradle6-rest-builder/modules/guestbook/guestbook-impl/build.gradle
@@ -1,41 +1,9 @@
-buildscript {
-	dependencies {
-		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.rest.builder", version: "1.0.114"
-	}
-
-	repositories {
-		mavenLocal()
-		maven {
-			url "/opt/dev/projects/github/liferay-portal/master/.m2-tmp"
-		}
-		maven {
-			url "https://repository-cdn.liferay.com/nexus/content/groups/public"
-		}
-	}
-}
-
 apply plugin: "com.liferay.portal.tools.rest.builder"
 
 dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.dxp.api", version:"7.3.10-ga1"
+
 	compile project(":modules:guestbook:guestbook-api")
-
-	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.10.3"
-	compileOnly group: "com.liferay", name: "com.liferay.petra.function"
-	compileOnly group: "com.liferay", name: "com.liferay.petra.string"
-	compileOnly group: "com.liferay", name: "com.liferay.portal.odata.api"
-	compileOnly group: "com.liferay", name: "com.liferay.portal.vulcan.api", version: "7.7.1"
-	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl"
-	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel"
-	compileOnly group: "commons-collections", name: "commons-collections"
-	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
-	compileOnly group: "javax.servlet", name: "javax.servlet-api"
-	compileOnly group: "javax.validation", name: "validation-api", version: "2.0.1.Final"
-	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api"
-	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
-	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations"
-	compileOnly group: "org.osgi", name: "org.osgi.core"
-
-	restBuilder group: "com.liferay", name: "com.liferay.portal.tools.rest.builder", version: "1.0.114"
 }
 
 group = "com.liferay.docs.guestbook"

--- a/gradle6-rest-builder/modules/guestbook/guestbook-test/build.gradle
+++ b/gradle6-rest-builder/modules/guestbook/guestbook-test/build.gradle
@@ -1,28 +1,8 @@
-configurations.all {
-	resolutionStrategy {
-		force group: "com.liferay.portal", name: "com.liferay.portal.test", version: "7.1.0"
-	}
-}
-
 dependencies {
-	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.10.3"
-	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.10.3"
-	testIntegrationCompile group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.10.3"
+	testIntegrationCompile group: "com.liferay.portal", name: "release.dxp.api", version:"7.3.10-ga1"
 	testIntegrationCompile group: "com.liferay", name: "com.liferay.arquillian.extension.junit.bridge", version: "1.0.19"
-	testIntegrationCompile group: "com.liferay", name: "com.liferay.petra.io"
-	testIntegrationCompile group: "com.liferay", name: "com.liferay.petra.reflect"
-	testIntegrationCompile group: "com.liferay", name: "com.liferay.petra.string"
-	testIntegrationCompile group: "com.liferay", name: "com.liferay.portal.odata.api"
-	testIntegrationCompile group: "com.liferay", name: "com.liferay.portal.vulcan.api", version: "7.7.1"
-	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel"
-	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.test", version: "7.1.0"
 	testIntegrationCompile group: "commons-beanutils", name: "commons-beanutils"
-	testIntegrationCompile group: "commons-lang", name: "commons-lang"
-	compileOnly group: "javax.servlet", name: "javax.servlet-api"
-	testIntegrationCompile group: "javax.ws.rs", name: "javax.ws.rs-api"
 	testIntegrationCompile group: "junit", name: "junit"
-	testIntegrationCompile group: "log4j", name: "log4j"
-	testIntegrationCompile group: "org.slf4j", name: "slf4j-api"
 	testIntegrationCompile project(":modules:guestbook:guestbook-api")
 	testIntegrationCompile project(":modules:guestbook:guestbook-client")
 }


### PR DESCRIPTION
I've managed to remove most of the REST Builder module dependencies using the release.{product}.api.

It was more like a empirical approach without fully understanding what was going on under the hood so I've may missed something...

Please take a look and maybe this could be a good update to the REST Builder template to avoid dependency errors and to ease maintainability.

Thank you!

Best regards, Javier